### PR TITLE
Fix build error on iOS

### DIFF
--- a/screen_brightness_ios/example/pubspec.yaml
+++ b/screen_brightness_ios/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the screen_brightness_ios plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.15.0-116.0.dev <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/screen_brightness_ios/ios/Classes/SwiftScreenBrightnessIosPlugin.swift
+++ b/screen_brightness_ios/ios/Classes/SwiftScreenBrightnessIosPlugin.swift
@@ -86,7 +86,7 @@ public class SwiftScreenBrightnessIosPlugin: NSObject, FlutterPlugin, FlutterApp
     }
 
     public func handleCurrentBrightnessChanged(_ currentBrightness: CGFloat) {
-        currentBrightnessChangeStreamHandler.addCurrentBrightnessToEventSink(CGFloat(currentBrightness))
+        currentBrightnessChangeStreamHandler.addCurrentBrightnessToEventSink(currentBrightness)
     }
 
     @objc private func onSystemBrightnessChanged(notification: Notification) {

--- a/screen_brightness_ios/ios/Classes/SwiftScreenBrightnessIosPlugin.swift
+++ b/screen_brightness_ios/ios/Classes/SwiftScreenBrightnessIosPlugin.swift
@@ -86,7 +86,7 @@ public class SwiftScreenBrightnessIosPlugin: NSObject, FlutterPlugin, FlutterApp
     }
 
     public func handleCurrentBrightnessChanged(_ currentBrightness: CGFloat) {
-        currentBrightnessChangeStreamHandler.addCurrentBrightnessToEventSink(Double(currentBrightness))
+        currentBrightnessChangeStreamHandler.addCurrentBrightnessToEventSink(CGFloat(currentBrightness))
     }
 
     @objc private func onSystemBrightnessChanged(notification: Notification) {


### PR DESCRIPTION
I fixed a following error. It caused at building for iOS app using `flutter build ios --no-codesign` command.

```
screen_brightness_ios/ios/Classes/SwiftScreenBrightnessIosPlugin.swift:89:78: error: cannot convert value of type 'Double' to expected argument type 'CGFloat'
currentBrightnessChangeStreamHandler.addCurrentBrightnessToEventSink(Double(currentBrightness))
                                                                     ^
                                                                     CGFloat(                 )
```

<details>
<summary>Before fixed</summary>

```
~/src/screen_brightness/screen_brightness_ios/example develop
❯ git show && flutter clean && flutter doctor && flutter build ios --no-codesign
commit bf376f8b57e8113c582c20bd5082614b220d852a (HEAD -> develop)
Author: niku <10890+niku@users.noreply.github.com>
Date:   Tue Dec 7 17:46:15 2021 +0900

    Relax support version

diff --git a/screen_brightness_ios/example/pubspec.yaml b/screen_brightness_ios/example/pubspec.yaml
index b45ec6e..a71145f 100644
--- a/screen_brightness_ios/example/pubspec.yaml
+++ b/screen_brightness_ios/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the screen_brightness_ios plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev

 environment:
-  sdk: ">=2.15.0-116.0.dev <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"

 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
Cleaning Xcode workspace...                                         3.4s
Deleting .dart_tool...                                               3ms
Deleting .packages...                                                1ms
Deleting Generated.xcconfig...                                       0ms
Deleting flutter_export_environment.sh...                            0ms
Deleting .flutter-plugins-dependencies...                            0ms
Deleting .flutter-plugins...                                         0ms
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, 2.5.3, on macOS 11.6 20G165 darwin-x64, locale ja-JP)
[✓] Android toolchain - develop for Android devices (Android SDK version 31.0.0)
[✓] Xcode - develop for iOS and macOS
[✓] Chrome - develop for the web
[✓] Android Studio (version 2020.3)
[✓] IntelliJ IDEA Ultimate Edition (version 2021.2)
[✓] VS Code (version 1.62.3)
[✓] Connected device (2 available)

• No issues found!
Running "flutter pub get" in example...                            628ms
Warning: Building for device with codesigning disabled. You will have to manually codesign before deploying to device.
Building com.aaassseee.screenBrightnessIosExample for device (ios-release)...
Warning: Missing build name (CFBundleShortVersionString).
Warning: Missing build number (CFBundleVersion).
Action Required: You must set a build name and number in the pubspec.yaml file version field before submitting to the App Store.
Running pod install...                                           1,534ms
Running Xcode build...
Xcode build done.                                            3.7s
Failed to build iOS app
Error output from Xcode build:
↳
    ** BUILD FAILED **


Xcode's output:
↳
    /Users/niku/src/screen_brightness/screen_brightness_ios/ios/Classes/SwiftScreenBrightnessIosPlugin.swift:89:78: error: cannot convert value of type 'Double' to expected argument type 'CGFloat'
            currentBrightnessChangeStreamHandler.addCurrentBrightnessToEventSink(Double(currentBrightness))
                                                                                 ^
                                                                                 CGFloat(                 )
    /Users/niku/src/screen_brightness/screen_brightness_ios/ios/Classes/SwiftScreenBrightnessIosPlugin.swift:89:78: error: cannot convert value of type 'Double' to expected argument type 'CGFloat'
            currentBrightnessChangeStreamHandler.addCurrentBrightnessToEventSink(Double(currentBrightness))
                                                                                 ^
                                                                                 CGFloat(                 )
    note: Using new build system
    note: Building targets in parallel
    note: Planning build
    note: Analyzing workspace
    note: Constructing build description
    note: Build preparation complete

════════════════════════════════════════════════════════════════════════════════
Building a deployable iOS app requires a selected Development Team with a
Provisioning Profile. Please ensure that a Development Team is selected by:
  1- Open the Flutter project's Xcode target with
       open ios/Runner.xcworkspace
  2- Select the 'Runner' project in the navigator then the 'Runner' target
     in the project settings
  3- Make sure a 'Development Team' is selected under Signing & Capabilities > Team.
     You may need to:
         - Log in with your Apple ID in Xcode first
         - Ensure you have a valid unique Bundle ID
         - Register your device with your Apple Developer Account
         - Let Xcode automatically provision a profile for your app
  4- Build or run your project again

For more information, please visit:
  https://flutter.dev/docs/get-started/install/macos#deploy-to-ios-devices

Or run on an iOS simulator without code signing
════════════════════════════════════════════════════════════════════════════════
Encountered error while building for device.
```

</details>
<details>
<summary>After fixed</summary>

```
~/src/screen_brightness/screen_brightness_ios/example develop ⇡
❯ git show && flutter clean && flutter doctor && flutter build ios --no-codesign
commit bcf2ae46047165d625c7c30b2bb6263361ca0088 (HEAD -> develop, niku/develop)
Author: niku <10890+niku@users.noreply.github.com>
Date:   Tue Dec 7 17:52:01 2021 +0900

    Fix Xcode's build error

    screen_brightness_ios/ios/Classes/SwiftScreenBrightnessIosPlugin.swift:89:78: error: cannot convert value of type 'Double' to expected argument type 'CGFloat'
    currentBrightnessChangeStreamHandler.addCurrentBrightnessToEventSink(Double(currentBrightness))
                                                                         ^
                                                                         CGFloat(                 )

diff --git a/screen_brightness_ios/ios/Classes/SwiftScreenBrightnessIosPlugin.swift b/screen_brightness_ios/ios/Classes/SwiftScreenBrightnessIosPlugin.swift
index 841c923..96e2d5e 100644
--- a/screen_brightness_ios/ios/Classes/SwiftScreenBrightnessIosPlugin.swift
+++ b/screen_brightness_ios/ios/Classes/SwiftScreenBrightnessIosPlugin.swift
@@ -86,7 +86,7 @@ public class SwiftScreenBrightnessIosPlugin: NSObject, FlutterPlugin, FlutterApp
     }

     public func handleCurrentBrightnessChanged(_ currentBrightness: CGFloat) {
-        currentBrightnessChangeStreamHandler.addCurrentBrightnessToEventSink(Double(currentBrightness))
+        currentBrightnessChangeStreamHandler.addCurrentBrightnessToEventSink(CGFloat(currentBrightness))
     }

     @objc private func onSystemBrightnessChanged(notification: Notification) {
Cleaning Xcode workspace...                                         3.7s
Deleting build...                                                  140ms
Deleting .dart_tool...                                              28ms
Deleting .packages...                                                2ms
Deleting Generated.xcconfig...                                       1ms
Deleting flutter_export_environment.sh...                            2ms
Deleting Flutter.podspec...                                          1ms
Deleting .flutter-plugins-dependencies...                            1ms
Deleting .flutter-plugins...                                         2ms
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, 2.5.3, on macOS 11.6 20G165 darwin-x64, locale ja-JP)
[✓] Android toolchain - develop for Android devices (Android SDK version 31.0.0)
[✓] Xcode - develop for iOS and macOS
[✓] Chrome - develop for the web
[✓] Android Studio (version 2020.3)
[✓] IntelliJ IDEA Ultimate Edition (version 2021.2)
[✓] VS Code (version 1.62.3)
[✓] Connected device (2 available)

• No issues found!
Running "flutter pub get" in example...                            617ms
Warning: Building for device with codesigning disabled. You will have to manually codesign before deploying to device.
Building com.aaassseee.screenBrightnessIosExample for device (ios-release)...
Warning: Missing build name (CFBundleShortVersionString).
Warning: Missing build number (CFBundleVersion).
Action Required: You must set a build name and number in the pubspec.yaml file version field before submitting to the App Store.
Running pod install...                                           1,552ms
Running Xcode build...
 └─Compiling, linking and signing...                         5.6s
Xcode build done.                                           41.5s
Built /Users/niku/src/screen_brightness/screen_brightness_ios/example/build/ios/iphoneos/Runner.app.
```
</details>
