### PR TITLE
Add iOS privacy manifests file

### DIFF
--- a/screen_brightness_ios/ios/Resources/PrivacyInfo.xcprivacy
+++ b/screen_brightness_ios/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/screen_brightness_ios/ios/screen_brightness_ios.podspec
+++ b/screen_brightness_ios/ios/screen_brightness_ios.podspec
@@ -16,6 +16,7 @@ The iOS federated plugin implementation of the screen_brightness.
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '9.0'
+  s.resource_bundles = {'screen_brightness_ios_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
## Related Issue

Fixes https://github.com/aaassseee/screen_brightness/issues/27

## Description

Added `PrivacyInfo.xcprivacy` to podspec of screen_brightness_ios.
I think screen_brightness_ios is internally using `UIScreen.main.brightness` to manage the screen brightness, however it is not accessing any of the required reason API. Therefore, I created an empty privacy manifests file.

## Reference

https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api