### PR TITLE
Added uses-permission and namespace to AndroidManifest.xml, add namespace info to README.md  Addresses #47

### DIFF
--- a/screen_brightness/README.md
+++ b/screen_brightness/README.md
@@ -17,8 +17,13 @@ latest_version:\
 
 To adjust the system brightness on Android, add the following permission in your `AndroidManifest.xml` file
 ```xml
+<!-- You must also ensure that the `xmlns:tools="http://schemas.android.com/tools"` namespace has been 
+    added to your <manifest> tag
+-->
 <uses-permission android:name="android.permission.WRITE_SETTINGS" tools:ignore="ProtectedPermissions"/>
 ```
+
+
 
 ### API
 #### System brightness

--- a/screen_brightness/example/android/app/src/main/AndroidManifest.xml
+++ b/screen_brightness/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,14 @@
+  <!-- SCREEN_BRIGHTNESS - NOTE: the xmlns:tools namespace attribute must be added to the manifest tag because it is used
+       within the uses-permissions line we need to add to adjust system brightness
+       add `xmlns:tools="http://schemas.android.com/tools"` to the <manifest> tag
+ -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   package="com.aaassseee.screen_brightness_example">
+
+  <!-- SCREEN_BRIGHTNESS - The following needs to be added in order to adjust the system brightness -->
+  <uses-permission android:name="android.permission.WRITE_SETTINGS" tools:ignore="ProtectedPermissions"/>
+
   <application
     android:icon="@mipmap/ic_launcher"
     android:label="screen_brightness_example">


### PR DESCRIPTION
This PR adds the `<uses-permission .. />` tag to the android example and it also adds a note to `README.md` about adding the `xmlns:tools="http://schemas.android.com/tools"` namespace to the `<manifest>` tag within the `AndroidManifest.xml`

