### PR TITLE
Fix: updated resetScreenBrightness deprecated message to correct new …

### DIFF
--- a/screen_brightness/lib/screen_brightness.dart
+++ b/screen_brightness/lib/screen_brightness.dart
@@ -188,7 +188,7 @@ class ScreenBrightness {
   /// (Android only) Code: -10, Message: Unexpected error on activity binding
   /// Unexpected error when getting activity, activity may be null
   @Deprecated(
-      'refactored to resetScreenBrightness (will be remove after version 2.1.0)')
+      'refactored to resetApplicationScreenBrightness (will be remove after version 2.1.0)')
   Future<void> resetScreenBrightness() => resetApplicationScreenBrightness();
 
   /// Reset application screen brightness with (Android) -1 or (iOS)system


### PR DESCRIPTION
…method name

Deprecated message for resetScreenBrightness was still showing the old method in it's message. Updated to new method resetApplicationScreenBrightness.