### PR TITLE
Crash fix when handling change and prop is missing

### DIFF
--- a/screen_brightness_android/android/src/main/kotlin/com/aaassseee/screen_brightness_android/ScreenBrightnessAndroidPlugin.kt
+++ b/screen_brightness_android/android/src/main/kotlin/com/aaassseee/screen_brightness_android/ScreenBrightnessAndroidPlugin.kt
@@ -51,10 +51,14 @@ class ScreenBrightnessAndroidPlugin : FlutterPlugin, MethodCallHandler, Activity
         override fun onChange(selfChange: Boolean) {
             super.onChange(selfChange)
             context?.let {
-                systemScreenBrightness = getSystemScreenBrightness(it)
-                systemScreenBrightnessChangedStreamHandler?.eventSink?.success(systemScreenBrightness)
-                if (applicationScreenBrightness == null) {
-                    applicationScreenBrightnessChangedStreamHandler?.eventSink?.success(systemScreenBrightness)
+                try {
+                    systemScreenBrightness = getSystemScreenBrightness(it)
+                    systemScreenBrightnessChangedStreamHandler?.eventSink?.success(systemScreenBrightness)
+                    if (applicationScreenBrightness == null) {
+                        applicationScreenBrightnessChangedStreamHandler?.eventSink?.success(systemScreenBrightness)
+                    }
+                } catch (e: Settings.SettingNotFoundException) {
+                    e.printStackTrace()
                 }
             }
         }


### PR DESCRIPTION
I got some crash reports in my app using this pluing, from a device where the "System.SCREEN_BRIGHTNESS" setting was missing when queried inside the `ContentObserver` change handler.

Obviously, this is strange that the setting would be missing even though this is a content observer specifically for that setting. Nonetheless the crash happened, with a Lenovo Tab K10 Gen 2 (Android 14). So the fix is a simple protection to prevent these crashes.