### PR TITLE
chore(ohos): migrate to new project structure

### DIFF
--- a/screen_brightness_ohos/example/ohos/.gitignore
+++ b/screen_brightness_ohos/example/ohos/.gitignore
@@ -9,7 +9,8 @@
 /.clang-format
 /.clang-tidy
 **/.test
-*.har
+/package.json
+/package-lock.json
 **/BuildProfile.ets
 **/oh-package-lock.json5
 

--- a/screen_brightness_ohos/example/ohos/entry/hvigorfile.ts
+++ b/screen_brightness_ohos/example/ohos/entry/hvigorfile.ts
@@ -14,4 +14,8 @@
 */
 
 // Script for compiling build behavior. It is built in the build plug-in and cannot be modified currently.
-export { hapTasks } from '@ohos/hvigor-ohos-plugin';
+import { hapTasks } from '@ohos/hvigor-ohos-plugin';
+export default {
+  system: hapTasks,
+  plugins: []
+}

--- a/screen_brightness_ohos/example/ohos/entry/oh-package.json5
+++ b/screen_brightness_ohos/example/ohos/entry/oh-package.json5
@@ -5,7 +5,5 @@
   "main": "",
   "author": "",
   "license": "",
-  "dependencies": {
-    "screen_brightness_ohos": "file:../har/screen_brightness_ohos.har"
-  }
+  "dependencies": {}
 }

--- a/screen_brightness_ohos/example/ohos/hvigorconfig.ts
+++ b/screen_brightness_ohos/example/ohos/hvigorconfig.ts
@@ -1,0 +1,4 @@
+import path from 'path'
+import { injectNativeModules } from 'flutter-hvigor-plugin';
+
+injectNativeModules(__dirname, path.dirname(__dirname))

--- a/screen_brightness_ohos/example/ohos/hvigorfile.ts
+++ b/screen_brightness_ohos/example/ohos/hvigorfile.ts
@@ -13,9 +13,11 @@
 * limitations under the License.
 */
 
+import path from 'path'
 import { appTasks } from '@ohos/hvigor-ohos-plugin';
+import { flutterHvigorPlugin } from 'flutter-hvigor-plugin';
 
 export default {
-    system: appTasks,  /* Built-in plugin of Hvigor. It cannot be modified. */
-    plugins:[]         /* Custom plugin to extend the functionality of Hvigor. */
+    system: appTasks,
+    plugins:[flutterHvigorPlugin(path.dirname(__dirname))]
 }

--- a/screen_brightness_ohos/example/ohos/oh-package.json5
+++ b/screen_brightness_ohos/example/ohos/oh-package.json5
@@ -6,15 +6,9 @@
   "main": "",
   "author": "",
   "license": "",
-  "dependencies": {
-    "@ohos/flutter_ohos": "file:./har/flutter.har"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@ohos/hypium": "1.0.6"
   },
-  "overrides": {
-    "@ohos/flutter_ohos": "file:./har/flutter.har",
-    "screen_brightness_ohos": "file:./har/screen_brightness_ohos.har",
-    "@ohos/flutter_module": "file:./entry"
-  }
+  "overrides": {}
 }

--- a/screen_brightness_ohos/ohos/oh-package.json5
+++ b/screen_brightness_ohos/ohos/oh-package.json5
@@ -5,7 +5,5 @@
   "main": "Index.ets",
   "author": "",
   "license": "Apache-2.0",
-  "dependencies": {
-    "@ohos/flutter_ohos": "file:libs/flutter.har"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Hi! This PR didn't add new features or fix any bug to ohos plugin, it's just an update of project structure according to [this document](https://gitcode.com/openharmony-tpc/flutter_flutter/pull/504), to make code lint for ohos work properly.