### PR TITLE
fix(screen_brightness): Fixes the issue where the channel return type does not match the method

### DIFF
--- a/screen_brightness_platform_interface/lib/method_channel_screen_brightness.dart
+++ b/screen_brightness_platform_interface/lib/method_channel_screen_brightness.dart
@@ -37,7 +37,7 @@ class MethodChannelScreenBrightness extends ScreenBrightnessPlatform {
   @override
   Future<double> get system async {
     final systemBrightness = await pluginMethodChannel
-        .invokeMethod<double>(methodNameGetSystemScreenBrightness);
+        .invokeMethod<num>(methodNameGetSystemScreenBrightness);
     if (systemBrightness == null) {
       throw PlatformException(code: "-9", message: "value returns null");
     }
@@ -46,7 +46,7 @@ class MethodChannelScreenBrightness extends ScreenBrightnessPlatform {
       throw RangeError.range(systemBrightness, minBrightness, maxBrightness);
     }
 
-    return systemBrightness;
+    return systemBrightness.toDouble();
   }
 
   /// Set system screen brightness with double value.
@@ -118,7 +118,7 @@ class MethodChannelScreenBrightness extends ScreenBrightnessPlatform {
   @override
   Future<double> get application async {
     final currentBrightness = await pluginMethodChannel
-        .invokeMethod<double>(methodNameGetApplicationScreenBrightness);
+        .invokeMethod<num>(methodNameGetApplicationScreenBrightness);
     if (currentBrightness == null) {
       throw PlatformException(code: "-9", message: "value returns null");
     }
@@ -127,7 +127,7 @@ class MethodChannelScreenBrightness extends ScreenBrightnessPlatform {
       throw RangeError.range(currentBrightness, minBrightness, maxBrightness);
     }
 
-    return currentBrightness;
+    return currentBrightness.toDouble();
   }
 
   /// Set application screen brightness with double value.


### PR DESCRIPTION
在鸿蒙上arkTS只有number类型，没有double。传到dart有时会变成int。
可能是适配鸿蒙flutter时MethodChannel的bug。
所以我只能在dart侧做类型兼容了

<img width="1518" height="898" alt="fe6b7aa83cc6cb923a92006e94c5968f" src="https://github.com/user-attachments/assets/ec6a7083-6b3d-4231-bd7c-7cd28f3fe3ed" />
