### PR TITLE
fix(android): bump compileOptions and jvmTarget to Java 17

### DIFF
--- a/screen_brightness_android/android/build.gradle.kts
+++ b/screen_brightness_android/android/build.gradle.kts
@@ -36,8 +36,8 @@ android {
     compileSdk = 36
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     sourceSets {
@@ -72,7 +72,7 @@ android {
 
 project.extensions.configure(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java) {
     compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 


### PR DESCRIPTION
## What
Bumps `screen_brightness_android`'s `compileOptions` (source/target compatibility) and Kotlin `jvmTarget` from Java 8 to Java 17.

## Why
The module currently targets Java 8 explicitly, which JDK 17+ flags as obsolete during compilation:

    warning: [options] source value 8 is obsolete and will be removed in a future release
    warning: [options] target value 8 is obsolete and will be removed in a future release

Any app consuming this plugin sees these warnings on every build. Java 17 is already the baseline used elsewhere in the project (compileSdk 36, AGP 9.0.1), so this just aligns the compile target with the rest of the toolchain — no behavior change expected.

## Testing
Verified the plugin still builds and the app consuming it no longer emits the Java 8 warnings.